### PR TITLE
build: explicitly disable OpenSSL support to improve startup latency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+coreutils (9.4-2-1deepin5) unstable; urgency=medium
+
+  * Explicitly disable OpenSSL support (--with-openssl=no) to eliminate 
+    dynamic linking overhead of libcrypto and libzstd.
+  * This restores the startup performance of basic utilities like 'sort', 
+    fixing a 15-25% regression observed in short-lived process benchmarks. 
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Wed, 11 Mar 2026 11:39:57 +0800
+
 coreutils (9.4-2-1deepin4) unstable; urgency=medium
 
   * implement USEC with libusec.so

--- a/debian/rules
+++ b/debian/rules
@@ -21,9 +21,9 @@ d=debian/coreutils
 override_dh_auto_configure:
 ifeq ($(shell if [ -f /etc/os-release ]; then grep -iq "uos" /etc/os-release; echo $$?; fi),0)
 	$(info Detected UOS system, enabling usec library support)
-	dh_auto_configure -- --enable-install-program=arch --with-openssl=auto-gpl-compat --with-usec
+	dh_auto_configure -- --enable-install-program=arch --with-openssl=no --with-usec
 else
-	dh_auto_configure -- --enable-install-program=arch --with-openssl=auto-gpl-compat
+	dh_auto_configure -- --enable-install-program=arch --with-openssl=no
 endif
 
 %:


### PR DESCRIPTION
The transition to OpenSSL 3.0 triggered the auto-gpl-compat check in gnulib, causing 'sort' and other core utilities to link against libcrypto and libzstd. This introduced significant dynamic linking overhead, accounting for ~32% of execution time in short-lived processes.

By passing --with-openssl=no, we decouple these utilities from heavyweight libraries, reverting to internal lightweight MD5 implementations. This fixes a 15-25% performance regression in benchmarks like UnixBench shell scripts.

Note: This will impact the hashing performance of md5sum/sha256sum on large files, but prioritizes the responsiveness of fundamental system tools.

显式禁用 OpenSSL 支持以优化启动延迟

由于 OpenSSL 3.0 的许可证兼容性触发了 gnulib 的自动探测机制，导致 sort
等基础工具被动链接了 libcrypto 和 libzstd。这引入了显著的动态链接开销，
在短进程执行中占比高达 32%。

通过显式指定 --with-openssl=no，我们将这些工具与重型库解耦，回退至内部
轻量化的 MD5 实现。此举解决了 UnixBench shell 脚本测试中 15-25% 的
性能回退问题。

注：此修改会影响 md5sum/sha256sum 在处理大文件时的哈希计算性能，但优先
保障了系统基础工具的响应速度。